### PR TITLE
Interface and trivial implementation for tcpinfo_lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ include_directories(${GTEST_INCLUDE_DIRS} ${COMMON_INCLUDES})
 
 set(SRC_DIR ${PROJECT_SOURCE_DIR}/src)
 add_executable(${PROJECT_TEST_NAME}
-    ${SRC_DIR}/empty_test.cc)
+    ${SRC_DIR}/tcpinfo_proto_test.cc)
 add_dependencies(${PROJECT_TEST_NAME} googletest)
 # add_dependencies(${PROJECT_TEST_NAME} iproute2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,5 @@
 cmake_minimum_required (VERSION 2.8.6)
 
-############### Source Tree Overview ######################
-# ├── build
-# ├── CMakeLists.txt
-# ├── ext
-# │   ├── gtest
-# │   │   └── CMakeLists.txt
-# │   ├── iproute2
-# │   │   └── CMakeLists.txt
-# │   └── protobuf
-# │       └── CMakeLists.txt
-# ├── install-protobuf.sh
-# ├── LICENSE
-# ├── README.md
-# └── src
-#     ├── tcpinfo.proto
-#     └── tcpinfo_proto_test.cc
-
 # Note that these must precede the ENABLE_LANGUAGE statements.
 set(CMAKE_C_COMPILER "/usr/bin/clang")
 set(CMAKE_CXX_COMPILER "/usr/bin/clang++")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ enable_testing()
 PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS
     ${SRC_DIR}/tcpinfo.proto)
 add_library(${PROJECT_NAME}
+    ${SRC_DIR}/tcpinfo_lib.cc ${SRC_DIR}/tcpinfo_lib.h
     ${PROTO_HDRS} ${PROTO_SRCS})
 
 ################### unit tests ########################

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ net-next branch of the iproute2 tools.  You will need cmake installed, and after
 When make finishes, there should be an iproute2 directory, and make should have successfully build all targets under iproute2.
 
 # Source tree
+```
 ├── build
 ├── CMakeLists.txt
 ├── ext
@@ -30,4 +31,4 @@ When make finishes, there should be an iproute2 directory, and make should have 
 └── src
     ├── tcpinfo.proto
     └── tcpinfo_proto_test.cc
-
+```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ When make finishes, there should be an iproute2 directory, and make should have 
 ├── LICENSE
 ├── README.md
 └── src
+    ├── tcpinfo_lib.cc
+    ├── tcpinfo_lib.h
     ├── tcpinfo.proto
     └── tcpinfo_proto_test.cc
 ```

--- a/src/empty_test.cc
+++ b/src/empty_test.cc
@@ -1,6 +1,0 @@
-#include <stdio.h>
-
-int main(int argc, char **argv) {
-  printf("PASS\n");
-  return 0;
-}

--- a/src/tcpinfo.proto
+++ b/src/tcpinfo.proto
@@ -236,13 +236,19 @@ message TCPInfoProto {
 
 }
 
+enum Protocol {
+  IPPROTO_TCP = 6;
+  IPPROTO_UDP = 17;
+  IPPROTO_DCCP = 33;
+}
+
 // Parent containing all info gathered through netlink library.
 message TCPDiagnosticsProto {
   // Info from struct inet_diag_msg, including socket_id;
   optional InetDiagMsgProto inet_diag_msg = 1;
 
   // From INET_DIAG_PROTOCOL message.
-  optional string diag_protocol        = 2;
+  optional Protocol diag_protocol        = 2;
   // From INET_DIAG_CONG message.
   optional string congestion_algorithm = 3;
 

--- a/src/tcpinfo_lib.cc
+++ b/src/tcpinfo_lib.cc
@@ -1,3 +1,16 @@
+// Copyright 2016 measurement-lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "tcpinfo_lib.h"
 

--- a/src/tcpinfo_lib.cc
+++ b/src/tcpinfo_lib.cc
@@ -18,11 +18,13 @@ namespace mlab {
 namespace netlink {
 
 TCPDiagnosticsProto TCPInfoParser::ParseNLMsg(
-    const struct nlmsghdr* msg) const {
-  return std::move(TCPDiagnosticsProto());
+    const struct nlmsghdr* msg, int protocol) const {
+  TCPDiagnosticsProto proto;
+  NLMsgToProto(msg, protocol, &proto);
+  return std::move(proto);
 }
 
-void TCPInfoParser::NLMsgToProto(const struct nlmsghdr* msg,
+void TCPInfoParser::NLMsgToProto(const struct nlmsghdr* nlh, int protocol,
                                  TCPDiagnosticsProto* proto) const {
 }
 
@@ -45,9 +47,13 @@ bool TCPInfoPoller::ClearFilter(ConnectionFilter::Token token) {
 }
 
 ConnectionFilter::Token TCPInfoPoller::AddFilter(ConnectionFilter filter,
-                               Handler on_close, Handler on_change) {}
+                               Handler on_close, Handler on_change) {
+  return ConnectionFilter::Token();
+}
 
-ConnectionFilter::Token TCPInfoPoller::AddFilter(ConnectionFilter filter) {}
+ConnectionFilter::Token TCPInfoPoller::AddFilter(ConnectionFilter filter) {
+  return ConnectionFilter::Token();
+}
 
 void TCPInfoPoller::OnClose(Handler& handler) {}
 void TCPInfoPoller::OnChange(Handler& handler) {}

--- a/src/tcpinfo_lib.cc
+++ b/src/tcpinfo_lib.cc
@@ -1,0 +1,44 @@
+
+#include "tcpinfo_lib.h"
+
+namespace mlab {
+namespace netlink {
+
+TCPDiagnosticsProto TCPInfoParser::ParseNLMsg(
+    const struct nlmsghdr* msg) const {
+  return std::move(TCPDiagnosticsProto());
+}
+
+void TCPInfoParser::NLMsgToProto(const struct nlmsghdr* msg,
+                                 TCPDiagnosticsProto* proto) const {
+}
+
+bool ConnectionFilter::Accept(
+    const mlab::netlink::InetSocketIDProto& socket) const {
+  return true;
+}
+bool ConnectionFilter::Accept(const struct nlmsghdr* msg) const {
+  return true;
+}
+
+void TCPInfoPoller::PollOnce() {}
+void TCPInfoPoller::PollContinuously(uint polling_interval_msec) {}
+
+void TCPInfoPoller::Break() {}
+void TCPInfoPoller::ClearCache() {}
+void TCPInfoPoller::ClearFilters() {}
+bool TCPInfoPoller::ClearFilter(ConnectionFilter::Token token) {
+  return false;
+}
+
+ConnectionFilter::Token TCPInfoPoller::AddFilter(ConnectionFilter filter,
+                               Handler on_close, Handler on_change) {}
+
+ConnectionFilter::Token TCPInfoPoller::AddFilter(ConnectionFilter filter) {}
+
+void TCPInfoPoller::OnClose(Handler& handler) {}
+void TCPInfoPoller::OnChange(Handler& handler) {}
+
+} // namespace netlink
+} // namespace mlab
+

--- a/src/tcpinfo_lib.cc
+++ b/src/tcpinfo_lib.cc
@@ -18,13 +18,13 @@ namespace mlab {
 namespace netlink {
 
 TCPDiagnosticsProto TCPInfoParser::ParseNLMsg(
-    const struct nlmsghdr* msg, int protocol) const {
+    const struct nlmsghdr* msg, Protocol protocol) const {
   TCPDiagnosticsProto proto;
   NLMsgToProto(msg, protocol, &proto);
-  return std::move(proto);
+  return proto;
 }
 
-void TCPInfoParser::NLMsgToProto(const struct nlmsghdr* nlh, int protocol,
+void TCPInfoParser::NLMsgToProto(const struct nlmsghdr* nlh, Protocol protocol,
                                  TCPDiagnosticsProto* proto) const {
 }
 
@@ -55,8 +55,8 @@ ConnectionFilter::Token TCPInfoPoller::AddFilter(ConnectionFilter filter) {
   return ConnectionFilter::Token();
 }
 
-void TCPInfoPoller::OnClose(Handler& handler) {}
-void TCPInfoPoller::OnChange(Handler& handler) {}
+void TCPInfoPoller::OnClose(Handler handler) {}
+void TCPInfoPoller::OnChange(Handler handler) {}
 
 } // namespace netlink
 } // namespace mlab

--- a/src/tcpinfo_lib.h
+++ b/src/tcpinfo_lib.h
@@ -1,0 +1,123 @@
+// Copyright 2016 measurement-lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Support for fetching tcp measurements through netlink library.
+//
+// This module will include several elements.
+//  Poller - monitors connection data and calls handlers on events.
+//  Parser - parses a single data record into protobuf format.
+//  Logger* - support for writing data records out to log files.
+//        * may be moved to separate module.
+
+#ifndef MLAB_TCPINFO_LIB_H_
+#define MLAB_TCPINFO_LIB_H_
+
+#include "tcpinfo.pb.h"
+
+#include <functional>
+#include <linux/netlink.h>
+
+namespace mlab {
+namespace netlink {
+
+// Key interface elements:
+//  1. Poll all tcp connections, and maintain cache of measurements for each
+//     connection.
+//  2. On connection close, create a mlab.netlink.TCPDiagnosticsProto and
+//     forward it to an arbitrary functor.
+//  3. Create snapshot of all ESTABLISHED connections, and return as
+//     vector<mlab.netlink.TCPDiagnosticsProto>.
+
+// TCPInfoParser parses a single nlmsg struct, and produces an
+// mlab.netlink.TCPDiagnosticsProto.  It is a class, so that we may later extend
+// it to support filtering and other configured behavior.
+class TCPInfoParser {
+ public:
+  // <msg> ownership NOT transfered.
+  TCPDiagnosticsProto ParseNLMsg(const struct nlmsghdr* msg);
+
+  // <msg> ownership NOT transfered.
+  void NLMsgToProto(const struct nlmsghdr* msg, TCPDiagnosticsProto* proto);
+};
+
+// A connection filter checks whether a connection should be reported or not.
+class ConnectionFilter {
+ public:
+  bool Accept(const mlab::netlink::InetSocketIDProto& socket);
+  bool Accept(const struct nlmsghdr* msg);
+};
+
+// Instance that polls the status of TCP connections, and calls a handler on
+// specified conditions.
+// Trigger conditions include:
+//   1. Connection closed (once per connection).
+//   2. Change observed (once per polling cycle on active connections).
+// Filtering:
+//   All triggering may be restricted to 4-tuples that match the union of a set
+//   of ConnectionFilters.
+
+// Handler to be called when an event occurs.
+// Message ownership is NOT transfered, and handler code should not retain
+// references to the message after returning.
+using Handler = std::function<void (struct nlmsghdr* msg)>;
+
+// Token for later removing a filter.
+struct FilterToken {};
+
+class TCPInfoPoller {
+ public:
+
+  // Request netlink data once, run any triggered behaviors, and update the
+  // data cache.
+  void PollOnce();
+
+  // Request netlink data in polling loop, running any triggered behaviors.
+  void PollContinuously(uint polling_interval_msec = 100);
+
+  void Break();  // Stop polling.
+
+  // Clear the cache of per tuple data.
+  void ClearCache();
+
+  // Remove all whitelist filters.
+  void ClearFilters();
+  // Remove a single whitelist filter.
+  bool ClearFilter(FilterToken token);
+
+  // This adds a filter for a specific handler.  Each connection accepted by
+  // this filter will be handled by on_close or on_change.  This does NOT
+  // prevent other handlers from also triggering on the same connections.
+  //
+  // For example, if we want to collect all polled data on a specific tuple
+  // for NDT, we could specify the filter for that tuple, and an on_change
+  // handler that reports the desired NDT data.
+  FilterToken AddFilter(ConnectionFilter filter, Handler on_close, Handler on_change);
+
+  // This adds a filter that allows some connections to be reported by the
+  // default OnClose or OnChange handler.  Reporting will trigger for any
+  // connection that is accepted by ANY of the filters added through this
+  // function.
+  FilterToken AddFilter(ConnectionFilter filter);
+
+  // Specify handlers that will be run on any events that do not match any of
+  // the tuple filters.
+  void OnClose(Handler& handler);
+  void OnChange(Handler& handler);
+
+};
+
+} // namespace netlink
+} // namespace mlab
+
+#endif  // MLAB_TCPINFO_LIB_H_

--- a/src/tcpinfo_lib.h
+++ b/src/tcpinfo_lib.h
@@ -46,10 +46,10 @@ class TCPInfoParser {
  public:
   // <msg> ownership NOT transfered.
   TCPDiagnosticsProto ParseNLMsg(const struct nlmsghdr* msg,
-                                 int protocol) const;
+                                 Protocol protocol) const;
 
   // <msg> ownership NOT transfered.
-  void NLMsgToProto(const struct nlmsghdr* msg, int protocol,
+  void NLMsgToProto(const struct nlmsghdr* msg, Protocol protocol,
                     TCPDiagnosticsProto* proto) const;
 };
 
@@ -115,8 +115,8 @@ class TCPInfoPoller {
 
   // Specify handlers that will be run on any events that do not match any of
   // the tuple filters.
-  void OnClose(Handler& handler);
-  void OnChange(Handler& handler);
+  void OnClose(Handler handler);
+  void OnChange(Handler handler);
 
 };
 

--- a/src/tcpinfo_lib.h
+++ b/src/tcpinfo_lib.h
@@ -45,10 +45,11 @@ namespace netlink {
 class TCPInfoParser {
  public:
   // <msg> ownership NOT transfered.
-  TCPDiagnosticsProto ParseNLMsg(const struct nlmsghdr* msg) const;
+  TCPDiagnosticsProto ParseNLMsg(const struct nlmsghdr* msg,
+                                 int protocol) const;
 
   // <msg> ownership NOT transfered.
-  void NLMsgToProto(const struct nlmsghdr* msg,
+  void NLMsgToProto(const struct nlmsghdr* msg, int protocol,
                     TCPDiagnosticsProto* proto) const;
 };
 

--- a/src/tcpinfo_lib.h
+++ b/src/tcpinfo_lib.h
@@ -45,10 +45,13 @@ namespace netlink {
 class TCPInfoParser {
  public:
   // <msg> ownership NOT transfered.
+  // <protocol> fallback if it is not specified in msg.
   TCPDiagnosticsProto ParseNLMsg(const struct nlmsghdr* msg,
                                  Protocol protocol) const;
 
   // <msg> ownership NOT transfered.
+  // <protocol> fallback if it is not specified in msg.
+  // <proto> output protobuf into which msg will be parsed.
   void NLMsgToProto(const struct nlmsghdr* msg, Protocol protocol,
                     TCPDiagnosticsProto* proto) const;
 };

--- a/src/tcpinfo_proto_test.cc
+++ b/src/tcpinfo_proto_test.cc
@@ -1,6 +1,21 @@
+// Copyright 2016 measurement-lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Placeholder for more interesting tests.
 
 #include "tcpinfo.pb.h"
+#include "tcpinfo_lib.h"
 #include "gtest/gtest.h"
 
 namespace mlab {
@@ -11,10 +26,6 @@ TEST(tcpinfo_proto, has_some_fields) {
 
   proto.set_diag_protocol("foobar");
   EXPECT_EQ(proto.diag_protocol(), "foobar");
-}
-
-TEST(tcpinfo_lib, parse_msg) {
-  EXPECT_TRUE(false);
 }
 
 }  // namespace netlink

--- a/src/tcpinfo_proto_test.cc
+++ b/src/tcpinfo_proto_test.cc
@@ -24,8 +24,8 @@ namespace netlink {
 TEST(tcpinfo_proto, has_some_fields) {
   TCPDiagnosticsProto proto;
 
-  proto.set_diag_protocol("foobar");
-  EXPECT_EQ(proto.diag_protocol(), "foobar");
+  proto.set_diag_protocol(Protocol(6));
+  EXPECT_EQ(proto.diag_protocol(), Protocol::IPPROTO_TCP);
 }
 
 }  // namespace netlink

--- a/src/tcpinfo_proto_test.cc
+++ b/src/tcpinfo_proto_test.cc
@@ -13,5 +13,7 @@ TEST(tcpinfo_proto, has_some_fields) {
   EXPECT_EQ(proto.diag_protocol(), "foobar");
 }
 
+TEST(tcpinfo_lib, parse_msg) {
+
 }
 }

--- a/src/tcpinfo_proto_test.cc
+++ b/src/tcpinfo_proto_test.cc
@@ -14,6 +14,8 @@ TEST(tcpinfo_proto, has_some_fields) {
 }
 
 TEST(tcpinfo_lib, parse_msg) {
+  EXPECT_TRUE(false);
+}
 
-}
-}
+}  // namespace netlink
+}  // namespace mlab


### PR DESCRIPTION
This introduces the interface definition for the library providing collection of tcp_info data through the netlink library.  An empty implementation is provided, so that basic compile and link can be tested.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcpinfo_lib/5)

<!-- Reviewable:end -->
