### PR TITLE
Many small improvements to cmake and travis configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ matrix:
           - gcc-4.9
           - g++-4.9
           - lcov
-      env: CXX_COMPILER=g++ C_COMPILER=gcc ENABLE_COVERAGE=true
+      env:
+        - CXX_COMPILER=g++ C_COMPILER=gcc
+        - COVERAGE_FLAGS="-g -O0 --coverage" # debug, no optimisation
 
 before_install:
 - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,50 @@ language: cpp
 
 matrix:
   include:
+    # Build with gcc and coverage.
     - compiler: gcc
       addons:
         apt:
           sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-3.9
           packages:
           - gcc-4.9
           - g++-4.9
           - lcov
+      install:
+        # Install coverage tools. (Used only for gcc build)
+        - cd ${TRAVIS_BUILD_DIR}
+        - sudo apt-get -qq install lcov
+        - gem install coveralls-lcov
+        - lcov --version
       env:
-        - CXX_COMPILER=g++ C_COMPILER=gcc
-        - COVERAGE_FLAGS="-g -O0 --coverage" # debug, no optimisation
+        - CXX_COMPILER=g++ C_COMPILER=gcc \
+          COVERAGE_FLAGS="-g -O0 --coverage" # debug, no optimization
+      after_success:
+        # Collect coverage data.
+        - cd ${TRAVIS_BUILD_DIR}
+        - lcov --directory build/ --capture -o coverage.info
+        - lcov -r coverage.info '*_test.cc' '*.pb.h' '*.pb.cc' '*/iproute2/*' '/usr/include/*' '*/gtest/*' -o coverage.info
+        - lcov --list coverage.info
+        # Upload the coverage info to coveralls.
+        - coveralls-lcov --repo-token ${COVERALLS_TOKEN} coverage.info
+
+    # Build with clang and optimization.
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-3.6
+          packages:
+          - clang-3.6
+          - lcov
+      env:
+        - CXX_COMPILER=clang++ C_COMPILER=clang
 
 before_install:
+- clang --version
 - sudo apt-get update -qq
-- sudo apt-get install -y libopencv-dev
 
 install:
 # install GTest and GMock
@@ -29,11 +56,6 @@ install:
 - "cd /usr/src/gtest && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
 - sudo apt-get -qq install google-mock
 - "cd /usr/src/gmock && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
-# Install coverage tools.
-- cd ${TRAVIS_BUILD_DIR}
-- sudo apt-get -qq install lcov
-- gem install coveralls-lcov
-- lcov --version
 - g++ --version
 
 before_cache:
@@ -48,19 +70,12 @@ cache:
 
 before_script:
 # Check if protobuf compiler is present, and load if it is not.
+# Note that this builds with gcc, regardless of which compiler is specified.
 - sudo ./install-protobuf.sh
 
 script:
 # Build and run tests.
 - cd build
-- cmake -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_C_COMPILER=$C_COMPILER .. && cmake --build .
+- cmake -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_C_COMPILER=$C_COMPILER -DCOVERAGE_FLAGS="$COVERAGE_FLAGS" .. && cmake --build .
 - ctest -V
 
-after_success:
-# Collect coverage data.
-- cd ${TRAVIS_BUILD_DIR}
-- lcov --directory build/ --capture -o coverage.info
-- lcov -r coverage.info '*_test.cc' '*.pb.h' '*.pb.cc' '*/iproute2/*' '/usr/include/*' '*/gtest/*' -o coverage.info
-- lcov --list coverage.info
-# Upload the coverage info to coveralls.
-- coveralls-lcov --repo-token ${COVERALLS_TOKEN} coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,8 @@ before_script:
 script:
 # Build and run tests.
 - cd build
-- cmake -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_C_COMPILER=$C_COMPILER -DCOVERAGE_FLAGS="$COVERAGE_FLAGS" .. && cmake --build .
+- cmake -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_C_COMPILER=$C_COMPILER \
+  -DCOVERAGE_FLAGS="$COVERAGE_FLAGS" ..
+- cmake --build .
 - ctest -V
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@ cmake_minimum_required (VERSION 2.8.6)
 ENABLE_LANGUAGE(C)
 ENABLE_LANGUAGE(CXX)
 
+# .travis.yml invokes CMake with CXX_COMPILER defined.  But on workstation,
+# we want to define that ourselves to be clang (if available).
+if (NOT DEFINED CXX_COMPILER)
+  set(CXX_COMPILER "clang++")
+  set(C_COMPILER "clang")
+endif (NOT DEFINED CXX_COMPILER)
+
 if (COVERAGE_FLAGS STREQUAL "")
 # If we aren't instrumenting for coverage, then add optimization flags.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,19 @@ cmake_minimum_required (VERSION 2.8.6)
 ENABLE_LANGUAGE(C)
 ENABLE_LANGUAGE(CXX)
 
-if (NOT DEFINED COVERAGE_FLAGS)
-  set(COVERAGE_FLAGS "-g -O0 --coverage") # debug, no optimisation
-endif()
-MESSAGE(STATUS "Coverage flags: " ${COVERAGE_FLAGS})
+if (COVERAGE_FLAGS STREQUAL "")
+# If we aren't instrumenting for coverage, then add optimization flags.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+else (COVERAGE_FLAGS STREQUAL "")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_FLAGS}")
+endif (COVERAGE_FLAGS STREQUAL "")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_FLAGS} -std=c++11 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+MESSAGE(STATUS "CXX flags: " ${CMAKE_CXX_FLAGS})
 
 # This allows the external project to push and pop environment.
 cmake_policy(SET CMP0011 OLD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,12 @@ cmake_minimum_required (VERSION 2.8.6)
 ENABLE_LANGUAGE(C)
 ENABLE_LANGUAGE(CXX)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
-# TODO(gfr) This should be conditional on coverage flags.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0") # debug, no optimisation
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage") # enabling coverage
+if (NOT DEFINED COVERAGE_FLAGS)
+  set(COVERAGE_FLAGS "-g -O0 --coverage") # debug, no optimisation
+endif()
+MESSAGE(STATUS "Coverage flags: " ${COVERAGE_FLAGS})
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_FLAGS} -std=c++11 -Wall")
 
 # This allows the external project to push and pop environment.
 cmake_policy(SET CMP0011 OLD)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # tcpinfo_lib
-Wrapper library for collecting data through netlink.
+[![Test Status](https://travis-ci.org/gfr10598/tcpinfo_lib.svg)](https://travis-ci.org/gfr10598/tcpinfo_lib)
+[![Coverage Status](https://coveralls.io/repos/github/gfr10598/tcpinfo_lib/badge.svg)](https://coveralls.io/github/gfr10598/tcpinfo_lib)
 
+Wrapper library for collecting data through netlink.
+ 
 NDT and Sidestream both will require functionality related to but not entirely provided by the netlink library.  This repository will hold primarily OO code that encapsulates calls to netlink library functions, and basic manipulation of the resulting instrumentation data, including protobuf generation.
 
 # Building
@@ -28,13 +31,19 @@ config is working, but will hopefully add clang config later.
 ├── CMakeLists.txt
 ├── ext
 │   ├── gtest
+│   │   └── CMakeLists.txt
 │   └── iproute2
+│       └── CMakeLists.txt
 ├── install-protobuf.sh
 ├── LICENSE
 ├── README.md
 └── src
+    ├── connection_cache.cc
+    ├── connection_cache.h
+    ├── connection_cache_test.cc
     ├── tcpinfo_lib.cc
     ├── tcpinfo_lib.h
+    ├── tcpinfo_lib_test.cc
     ├── tcpinfo.proto
     └── tcpinfo_proto_test.cc
 ```

--- a/install-protobuf.sh
+++ b/install-protobuf.sh
@@ -4,7 +4,7 @@
 
 set -x
 # check to see if protobuf tools already exist.
-LIBS=`/usr/bin/pkg-config --libs protobufxxx`
+LIBS=`/usr/bin/pkg-config --libs protobuf`
 if [ $? -ne 0 ] ; then
   if [ -r protobuf/configure ] ; then
     echo "Using cached protobuf."

--- a/install-protobuf.sh
+++ b/install-protobuf.sh
@@ -11,15 +11,20 @@ if [ $? -ne 0 ] ; then
     cd protobuf
     sudo make install && sudo ldconfig
   else
+    set -e
     echo "Install protobuf from web."
     git clone https://github.com/google/protobuf.git
-    # For unknown reason, compiling protobuf on travis-ci breaks with clang.
+    # For unknown reasons, compiling protobuf on travis-ci breaks with clang.
     # So we override to always use gcc.
     CC=gcc
     CXX=g++
-    cd protobuf && git checkout v3.1.0
-    ./autogen.sh && ./configure --prefix=/usr && make && \
-      sudo make install && sudo ldconfig
+    cd protobuf
+    git checkout v3.1.0
+    ./autogen.sh
+    ./configure --prefix=/usr
+    make
+    sudo make install
+    sudo ldconfig
   fi
 else
   echo "Protobuf already installed."

--- a/install-protobuf.sh
+++ b/install-protobuf.sh
@@ -4,7 +4,7 @@
 
 set -x
 # check to see if protobuf tools already exist.
-LIBS=`/usr/bin/pkg-config --libs protobuf`
+LIBS=`/usr/bin/pkg-config --libs protobufxxx`
 if [ $? -ne 0 ] ; then
   if [ -r protobuf/configure ] ; then
     echo "Using cached protobuf."
@@ -13,8 +13,13 @@ if [ $? -ne 0 ] ; then
   else
     echo "Install protobuf from web."
     git clone https://github.com/google/protobuf.git
+    # For unknown reason, compiling protobuf on travis-ci breaks with clang.
+    # So we override to always use gcc.
+    CC=gcc
+    CXX=g++
     cd protobuf && git checkout v3.1.0
-    ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && sudo ldconfig
+    ./autogen.sh && ./configure --prefix=/usr && make && \
+      sudo make install && sudo ldconfig
   fi
 else
   echo "Protobuf already installed."


### PR DESCRIPTION
Add test and build badges (in readme)
Add clang config for travis (without coverage)
Fix install-protobuf so that it always uses gcc.
Pass coverage flags from travis into cmake.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcpinfo_lib/9)
<!-- Reviewable:end -->
