### PR TITLE
remove line continuation in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,7 @@ before_script:
 script:
 # Build and run tests.
 - cd build
-- cmake -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_C_COMPILER=$C_COMPILER \
-  -DCOVERAGE_FLAGS="$COVERAGE_FLAGS" ..
+- cmake -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_C_COMPILER=$C_COMPILER -DCOVERAGE_FLAGS="$COVERAGE_FLAGS" ..
 - cmake --build .
 - ctest -V
 


### PR DESCRIPTION
Accidentally broke the travis config.  travis apparently doesn't recognize line continuation with \

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcpinfo_lib/10)
<!-- Reviewable:end -->
