### PR TITLE
Fix some missing cmake bits for building on minimal ubuntu install.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ include_directories(${IPROUTE2_INCLUDE_DIRS})
 link_directories(${IPROUTE2_LIBS_DIR})
 
 ################### protobuf compiler ########################
-find_package(Threads REQUIRED)
+execute_process(COMMAND ${PROJECT_SOURCE_DIR}/install-protobuf.sh)
 find_package(Protobuf REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ add_test(tcpinfo_proto tcpinfo_proto_test)
 ################### connection_cache library  ########################
 add_library(connection_cache_lib
     ${SRC_DIR}/connection_cache.cc ${SRC_DIR}/connection_cache.h)
-target_link_libraries(connection_cache_lib Threads::Threads)
+target_link_libraries(connection_cache_lib pthread)
 
    #================= unit tests ======================
 add_executable(connection_cache_test

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Wrapper library for collecting data through netlink.
  
 NDT and Sidestream both will require functionality related to but not entirely provided by the netlink library.  This repository will hold primarily OO code that encapsulates calls to netlink library functions, and basic manipulation of the resulting instrumentation data, including protobuf generation.
 
+# Prerequisites
+General requirements for building this repository
+```
+sudo apt-get install build-essential autoconf automake make cmake
+sudo apt-get install clang g++ libtool curl unzip bison flex
+```
+
 # Building
 ```
 git clone git@github.com:gfr10598/tcpinfo_lib

--- a/install-protobuf.sh
+++ b/install-protobuf.sh
@@ -2,7 +2,6 @@
 # Check out, build, and install protobuf support.
 # Building from source as that is recommended in protobuf README.md file.
 
-set -x
 # check to see if protobuf tools already exist.
 LIBS=`/usr/bin/pkg-config --libs protobuf`
 if [ $? -ne 0 ] ; then


### PR DESCRIPTION
This now works on a bare ubuntu install on virtualbox.
You need to execute the two sudo apt-get install commands, then the build instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcpinfo_lib/13)
<!-- Reviewable:end -->
