### PR TITLE
fix install-protobuf script to reject old version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS
 add_library(tcpinfo_lib
     ${SRC_DIR}/tcpinfo_lib.cc ${SRC_DIR}/tcpinfo_lib.h
     ${SRC_DIR}/tcpinfo_c_adapter.h ${SRC_DIR}/tcpinfo_c_adapter.c
-    ${PROTO_HDRS} ${PROTO_SRCS})
+    ${SRC_DIR}/gtest_prod.h ${PROTO_HDRS} ${PROTO_SRCS})
 add_dependencies(tcpinfo_lib iproute2)
 
 target_link_libraries(tcpinfo_lib

--- a/install-protobuf.sh
+++ b/install-protobuf.sh
@@ -4,7 +4,8 @@
 
 # check to see if protobuf tools already exist.
 LIBS=`/usr/bin/pkg-config --libs protobuf`
-if [ $? -ne 0 ] ; then
+PB_VER=`protoc --version`
+if [[ ($? -ne 0) ||  ("${PB_VER}" < "libprotoc 3.1.0") || (-z "${LIBS}")]]; then
   if [ -r protobuf/configure ] ; then
     echo "Using cached protobuf."
     cd protobuf

--- a/src/gtest_prod.h
+++ b/src/gtest_prod.h
@@ -1,0 +1,9 @@
+// This is just a local copy of googletest gtest_prod.h, to avoid
+// the dependency on the gtest library for production only sources.
+
+#ifndef GTEST_INCLUDE_GTEST_GTEST_PROD_H_
+#define GTEST_INCLUDE_GTEST_GTEST_PROD_H_
+#define FRIEND_TEST(test_case_name, test_name)\
+friend class test_case_name##_##test_name##_Test
+#endif  // GTEST_INCLUDE_GTEST_GTEST_PROD_H_
+

--- a/src/tcpinfo_lib.h
+++ b/src/tcpinfo_lib.h
@@ -24,7 +24,7 @@
 
 #include "connection_cache.h"
 #include "tcpinfo.pb.h"
-#include "gtest/gtest_prod.h"
+#include "gtest_prod.h"  // Using local copy instead of library include.
 
 extern "C" {
 #include <linux/inet_diag.h>  // Should come from iproute2 submodule.


### PR DESCRIPTION
Our proto definitions use "oneof" which is relatively new.  The script does not currently check the version, so this PR adds version checking, and installs a more recent version if version < 3.1.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcpinfo_lib/16)
<!-- Reviewable:end -->
